### PR TITLE
Potential fix for code scanning alert no. 10: Clear text storage of sensitive information

### DIFF
--- a/src/Shared.Core/Services/LicenseService.cs
+++ b/src/Shared.Core/Services/LicenseService.cs
@@ -279,7 +279,10 @@ public class LicenseService : ILicenseService
             await _licenseRepository.SaveChangesAsync();
 
             var licenseKeyHash = HashLicenseKey(licenseKey);
-            _logger.LogInformation("Trial license created for device {DeviceId}", request.DeviceId);
+            _logger.LogInformation(
+                "Trial license created for device {DeviceId} (LicenseKeyHash: {LicenseKeyHash})",
+                request.DeviceId,
+                licenseKeyHash);
 
             return new LicenseActivationResult
             {


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/NafisianCastle/dokanio/security/code-scanning/10](https://github.com/NafisianCastle/dokanio/security/code-scanning/10)

In general, the fix is to avoid storing or logging sensitive values such as license keys in clear text. For logging, the usual pattern is either (a) omit the secret entirely, or (b) log a non-sensitive derivative (for example, a hash or a truncated/masked form) that is still useful for correlation and debugging but cannot be abused as the original secret.

In this specific case, the problematic behavior is at line 261, where `{LicenseKey}` is included in the log template and the `licenseKey` value is passed as an argument. The best, least intrusive fix that preserves existing functionality is:
- Stop logging the full license key.
- Instead, log a non-reversible hash or at least a partially masked key so operators can still correlate log entries with a specific license if necessary, without revealing the usable key.

We can implement this entirely inside `LicenseService.cs` by:
1. Adding a `using System.Security.Cryptography;` import at the top (a standard .NET library).
2. Introducing a small private helper method in `LicenseService` to hash the license key, such as `private static string HashLicenseKey(string licenseKey)` using `SHA256`.
3. Updating the log statement on line 261 to remove the raw `{LicenseKey}` and instead log a derived value like `{LicenseKeyHash}` obtained by calling the helper method.

No other behavior of the service changes: the license is stored and returned as before, only the logging output is made safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **Auto-created Ticket**

[#16](https://github.com/NafisianCastle/dokanio/issues/16)

### **PR Type**
Bug fix, Security


___

### **Description**
- Prevents sensitive license keys from being logged in clear text

- Implements SHA-256 hashing for safe license key correlation in logs

- Adds private helper method to hash license keys before logging

- Maintains existing functionality while securing sensitive data exposure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["License Key"] --> B["HashLicenseKey Method"]
  B --> C["SHA-256 Hash"]
  C --> D["Log Hash Instead of Raw Key"]
  D --> E["Secure Logging Output"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LicenseService.cs</strong><dd><code>Secure license key logging with SHA-256 hashing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Shared.Core/Services/LicenseService.cs

<ul><li>Added <code>using System.Security.Cryptography;</code> import for SHA-256 hashing<br> <li> Introduced private static method <code>HashLicenseKey()</code> that computes <br>SHA-256 hash of license keys<br> <li> Updated trial license creation log statement to use hashed license key <br>instead of raw key<br> <li> Maintains all existing service functionality while securing sensitive <br>data in logs</ul>


</details>


  </td>
  <td><a href="https://github.com/NafisianCastle/dokanio/pull/15/files#diff-b1a4da8c0fe6140f4af1c1e4e654e1c4b5913c85d3735fdcaffcf81c62edacaf">+22/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

