### PR TITLE
Potential fix for code scanning alert no. 13: Insecure randomness

### DIFF
--- a/src/Shared.Core/Tests/DataEncryptionPropertyTest.cs
+++ b/src/Shared.Core/Tests/DataEncryptionPropertyTest.cs
@@ -7,6 +7,7 @@ using Shared.Core.Enums;
 using Shared.Core.Repositories;
 using Shared.Core.Services;
 using Xunit;
+using System.Security.Cryptography;
 
 namespace Shared.Core.Tests;
 
@@ -217,12 +218,12 @@ public class DataEncryptionPropertyTest : IDisposable
         // Add random generated data
         for (int i = 0; i < 10; i++)
         {
-            var length = random.Next(1, 200);
-            var randomString = GenerateRandomString(length, random);
+            var length = RandomNumberGenerator.GetInt32(1, 200);
+            var randomString = GenerateRandomString(length);
             dataSets.Add(new SensitiveDataTestSet 
             { 
                 PlainText = randomString, 
-                IsPassword = random.Next(0, 3) == 0 // 33% chance of being treated as password
+                IsPassword = RandomNumberGenerator.GetInt32(0, 3) == 0 // 33% chance of being treated as password
             });
         }
         
@@ -238,14 +239,15 @@ public class DataEncryptionPropertyTest : IDisposable
     /// <summary>
     /// Generates a random string of specified length
     /// </summary>
-    private static string GenerateRandomString(int length, Random random)
+    private static string GenerateRandomString(int length)
     {
         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+-=[]{}|;':\",./<>? \t\n";
         var result = new char[length];
         
         for (int i = 0; i < length; i++)
         {
-            result[i] = chars[random.Next(chars.Length)];
+            var index = RandomNumberGenerator.GetInt32(chars.Length);
+            result[i] = chars[index];
         }
         
         return new string(result);


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/NafisianCastle/dokanio/security/code-scanning/13](https://github.com/NafisianCastle/dokanio/security/code-scanning/13)

In general, to fix insecure randomness in a security context, replace uses of `System.Random` for generating secrets (passwords, tokens, salts, keys, etc.) with a cryptographically secure PRNG such as `System.Security.Cryptography.RandomNumberGenerator` or helpers like `RandomNumberGenerator.GetInt32`. This ensures that generated values are not trivially predictable.

For this file, the issue arises from `GenerateRandomSensitiveData` and `GenerateRandomString` using `Random` to generate random strings that are later used as (pseudo-)passwords in hashing/verification tests. We can keep the existing test logic and signatures but change the implementation to use a secure RNG. The simplest, least intrusive fix is:

- Add a `using System.Security.Cryptography;` import.
- Replace the `Random random` use in `GenerateRandomSensitiveData` so that:
  - `length` is drawn via `RandomNumberGenerator.GetInt32(1, 200)`.
  - The 33% password flag uses a secure random boolean based on `RandomNumberGenerator.GetInt32(0, 3)`.
- Change `GenerateRandomString` to no longer accept a `Random` parameter and instead use `RandomNumberGenerator.GetInt32` inside the loop to pick each character index.
- Update the call site from `GenerateRandomString(length, random)` to `GenerateRandomString(length)` to match the new signature.

This keeps behavior essentially the same (random variety of strings and password flags) but eliminates `System.Random` from the test data generation path that CodeQL tracks into the security-sensitive hashing logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix


___

### **Description**
- Replace insecure `System.Random` with cryptographically secure `RandomNumberGenerator`

- Update `GenerateRandomSensitiveData` to use `RandomNumberGenerator.GetInt32` for length and password flag

- Refactor `GenerateRandomString` to remove `Random` parameter and use secure RNG internally

- Add `System.Security.Cryptography` namespace import


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["System.Random<br/>Insecure RNG"] -->|Replace| B["RandomNumberGenerator<br/>Cryptographically Secure"]
  C["GenerateRandomString<br/>with Random param"] -->|Refactor| D["GenerateRandomString<br/>uses secure RNG internally"]
  E["GenerateRandomSensitiveData<br/>calls with Random"] -->|Update| F["GenerateRandomSensitiveData<br/>uses RandomNumberGenerator.GetInt32"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataEncryptionPropertyTest.cs</strong><dd><code>Replace System.Random with cryptographically secure RNG</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/Shared.Core/Tests/DataEncryptionPropertyTest.cs

<ul><li>Added <code>using System.Security.Cryptography;</code> import for secure random <br>number generation<br> <li> Replaced <code>random.Next(1, 200)</code> with <code>RandomNumberGenerator.GetInt32(1, </code><br><code>200)</code> for length generation<br> <li> Replaced <code>random.Next(0, 3)</code> with <code>RandomNumberGenerator.GetInt32(0, 3)</code> <br>for password flag determination<br> <li> Removed <code>Random random</code> parameter from <code>GenerateRandomString</code> method <br>signature<br> <li> Updated <code>GenerateRandomString</code> implementation to use <br><code>RandomNumberGenerator.GetInt32(chars.Length)</code> for character selection<br> <li> Updated call site to <code>GenerateRandomString(length)</code> without passing <br>random instance</ul>


</details>


  </td>
  <td><a href="https://github.com/NafisianCastle/dokanio/pull/34/files#diff-adaaad6d212889390a7db957746b613c2fcfb8429b103fe6741e7c7b097acf08">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

