### PR TITLE
Potential fix for code scanning alert no. 58: Clear text storage of sensitive information

### DIFF
--- a/src/Shared.Core/Services/LicenseService.cs
+++ b/src/Shared.Core/Services/LicenseService.cs
@@ -127,19 +127,19 @@ public class LicenseService : ILicenseService
             var license = await _licenseRepository.GetByLicenseKeyAsync(licenseKey);
             if (license == null)
             {
-                _logger.LogWarning("License key not found: {LicenseKey}", MaskLicenseKey(licenseKey));
+                _logger.LogWarning("License key not found. LicenseKeyHash: {LicenseKeyHash}", HashLicenseKey(licenseKey));
                 return false;
             }
 
             if (license.Status != LicenseStatus.Active)
             {
-                _logger.LogWarning("License is not active: {LicenseKey}, Status: {Status}", MaskLicenseKey(licenseKey), license.Status);
+                _logger.LogWarning("License is not active. LicenseKeyHash: {LicenseKeyHash}, Status: {Status}", HashLicenseKey(licenseKey), license.Status);
                 return false;
             }
 
             if (license.ExpiryDate < DateTime.UtcNow)
             {
-                _logger.LogWarning("License has expired: {LicenseKey}, ExpiryDate: {ExpiryDate}", MaskLicenseKey(licenseKey), license.ExpiryDate);
+                _logger.LogWarning("License has expired. LicenseKeyHash: {LicenseKeyHash}, ExpiryDate: {ExpiryDate}", HashLicenseKey(licenseKey), license.ExpiryDate);
                 return false;
             }
 
@@ -150,12 +150,12 @@ public class LicenseService : ILicenseService
             await _licenseRepository.UpdateAsync(license);
             await _licenseRepository.SaveChangesAsync();
 
-            _logger.LogInformation("License activated successfully: {LicenseKey} for device {DeviceId}", MaskLicenseKey(licenseKey), deviceId);
+            _logger.LogInformation("License activated successfully. LicenseKeyHash: {LicenseKeyHash} for device {DeviceId}", HashLicenseKey(licenseKey), deviceId);
             return true;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error activating license: {LicenseKey}", MaskLicenseKey(licenseKey));
+            _logger.LogError(ex, "Error activating license. LicenseKeyHash: {LicenseKeyHash}", HashLicenseKey(licenseKey));
             return false;
         }
     }


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/NafisianCastle/dokanio/security/code-scanning/58](https://github.com/NafisianCastle/dokanio/security/code-scanning/58)

General fix approach: Avoid storing or logging any portion of the raw license key in clear text. Instead, use a non-reversible representation (such as a SHA-256 hash) for correlation, or fully redact the value. Since this is about logging, we can keep existing behavior (correlation and debugging) by logging the hash of the license key, which is already provided by `HashLicenseKey`, and optionally a fully masked placeholder that reveals no actual characters.

Best concrete fix here: change the logging statements in `ActivateLicenseAsync` (and any other relevant locations, but in the provided snippet only line 153 is highlighted) to use `HashLicenseKey(licenseKey)` (and/or a fully redacted mask) instead of `MaskLicenseKey(licenseKey)` that reveals characters from the key. Because `HashLicenseKey` already exists in this file and uses `SHA256.Create`, no new imports are required. To maintain context in logs but eliminate cleartext exposure, we can log the hash in a dedicated structured property (for example, `{LicenseKeyHash}`) and, if desired, a constant redacted string instead of the key itself.

Specifically for the shown code:
- In `ActivateLicenseAsync`, update all `_logger.Log...` calls that include `{LicenseKey}` with `MaskLicenseKey` to instead log either:
  - only the hash using `HashLicenseKey(licenseKey)` with a new property name like `{LicenseKeyHash}`, or
  - a strictly redacted placeholder string like `"REDACTED"` for `{LicenseKey}` plus a separate `{LicenseKeyHash}` argument.
- Because the finding is about clear text storage, ensuring that no actual characters of the license key ever reach logs is sufficient to address all listed alert variants. The helper `HashLicenseKey` already exists, so the change is only to those logging calls; no extra methods or imports are needed.

Below I’ll implement the minimal, consistent change: log `HashLicenseKey(licenseKey)` as `LicenseKeyHash` in all the relevant log statements in `ActivateLicenseAsync` and stop logging any cleartext or partially revealed license key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix


___

### **Description**
- Replace masked license key logging with SHA-256 hash

- Prevent clear text storage of sensitive license information

- Update all logging statements in `ActivateLicenseAsync` method

- Use existing `HashLicenseKey` helper for non-reversible representation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Logging with MaskLicenseKey<br/>reveals partial characters"] -- "Security Risk" --> B["Clear text exposure<br/>in logs"]
  C["Use HashLicenseKey<br/>instead"] -- "Non-reversible" --> D["SHA-256 hash<br/>in logs"]
  D -- "Maintains" --> E["Correlation &<br/>debugging capability"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LicenseService.cs</strong><dd><code>Replace masked key logging with SHA-256 hash</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Shared.Core/Services/LicenseService.cs

<ul><li>Replace <code>MaskLicenseKey(licenseKey)</code> with <code>HashLicenseKey(licenseKey)</code> in <br>5 logging statements<br> <li> Update log message templates to use <code>{LicenseKeyHash}</code> instead of <br><code>{LicenseKey}</code><br> <li> Affected log calls: warning for not found, not active, expired states; <br>info for successful activation; error for exceptions<br> <li> Eliminates clear text exposure while preserving log correlation and <br>debugging capability</ul>


</details>


  </td>
  <td><a href="https://github.com/NafisianCastle/dokanio/pull/44/files#diff-b1a4da8c0fe6140f4af1c1e4e654e1c4b5913c85d3735fdcaffcf81c62edacaf">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

