### PR TITLE
Potential fix for code scanning alert no. 80: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/NafisianCastle/dokanio/security/code-scanning/80](https://github.com/NafisianCastle/dokanio/security/code-scanning/80)

Add an explicit `permissions` block to the workflow with the minimum required scope.  
Best fix here: set workflow-level permissions to `contents: read`, since the shown job only checks out code and runs restore/tests. This avoids changing behavior while ensuring token access is explicitly limited.

**Where to change:** `.github/workflows/dotnet.yml`, near the top-level keys (`name`, `on`, `jobs`).  
**What to add:**  
```yml
permissions:
  contents: read
```
No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
