### PR TITLE
Potential fix for code scanning alert no. 85: Clear text storage of sensitive information

### DIFF
--- a/src/Shared.Core/Services/LicenseService.cs
+++ b/src/Shared.Core/Services/LicenseService.cs
@@ -126,19 +126,19 @@ public class LicenseService : ILicenseService
             var license = await _licenseRepository.GetByLicenseKeyAsync(licenseKey);
             if (license == null)
             {
-                _logger.LogWarning("License key not found. LicenseKeyHash: {LicenseKeyHash}", HashLicenseKey(licenseKey));
+                _logger.LogWarning("License key not found.");
                 return false;
             }
 
             if (license.Status != LicenseStatus.Active)
             {
-                _logger.LogWarning("License is not active. LicenseKeyHash: {LicenseKeyHash}, Status: {Status}", HashLicenseKey(licenseKey), license.Status);
+                _logger.LogWarning("License is not active. Status: {Status}", license.Status);
                 return false;
             }
 
             if (license.ExpiryDate < DateTime.UtcNow)
             {
-                _logger.LogWarning("License has expired. LicenseKeyHash: {LicenseKeyHash}, ExpiryDate: {ExpiryDate}", HashLicenseKey(licenseKey), license.ExpiryDate);
+                _logger.LogWarning("License has expired. ExpiryDate: {ExpiryDate}", license.ExpiryDate);
                 return false;
             }
 
@@ -149,12 +149,12 @@ public class LicenseService : ILicenseService
             await _licenseRepository.UpdateAsync(license);
             await _licenseRepository.SaveChangesAsync();
 
-            _logger.LogInformation("License activated successfully. LicenseKeyHash: {LicenseKeyHash} for device {DeviceId}", HashLicenseKey(licenseKey), deviceId);
+            _logger.LogInformation("License activated successfully for device {DeviceId}", deviceId);
             return true;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error activating license. LicenseKeyHash: {LicenseKeyHash}", HashLicenseKey(licenseKey));
+            _logger.LogError(ex, "Error activating license.");
             return false;
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/NafisianCastle/dokanio/security/code-scanning/85](https://github.com/NafisianCastle/dokanio/security/code-scanning/85)

The best fix is to **remove sensitive-key-derived values from log storage** while keeping operational logging useful.  
In this file, replace log templates and arguments that include `HashLicenseKey(licenseKey)` with non-sensitive context (status, expiry, device ID, exception, etc.). This preserves functionality (activation logic and return values stay unchanged) and avoids storing sensitive data or reversible/correlatable derivatives.

In `src/Shared.Core/Services/LicenseService.cs`, update the logging calls in the shown method region:

- Line 129: remove `LicenseKeyHash` placeholder and argument.
- Line 135: keep status logging, remove `LicenseKeyHash`.
- Line 141: keep expiry logging, remove `LicenseKeyHash`.
- Line 152: keep device logging, remove `LicenseKeyHash`.
- Line 157: remove `LicenseKeyHash` from error log.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
